### PR TITLE
Dsl2 publish

### DIFF
--- a/pipeline/dsl2/boonstim.dot
+++ b/pipeline/dsl2/boonstim.dot
@@ -1,0 +1,590 @@
+digraph "boonstim" {
+p0 [shape=point,label="",fixedsize=true,width=0.1,xlabel="Channel.from"];
+p1 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="filter"];
+p0 -> p1;
+
+p1 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="filter"];
+p2 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="take"];
+p1 -> p2;
+
+p2 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="take"];
+p3 [label="cifti_meshing:ciftify_invocation"];
+p2 -> p3 [label="subs"];
+
+p3 [label="cifti_meshing:ciftify_invocation"];
+p4 [label="cifti_meshing:ciftify"];
+p3 -> p4;
+
+p4 [label="cifti_meshing:ciftify"];
+p63 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p4 -> p63 [label="$out1"];
+
+p4 [label="cifti_meshing:ciftify"];
+p6 [shape=point];
+p4 -> p6 [label="$out0"];
+
+p4 [label="cifti_meshing:ciftify"];
+p5 [shape=point];
+p4 -> p5 [label="$out3"];
+
+p2 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="take"];
+p7 [label="cifti_meshing:fmriprep_invocation"];
+p2 -> p7 [label="subs"];
+
+p7 [label="cifti_meshing:fmriprep_invocation"];
+p8 [label="cifti_meshing:fmriprep_anat"];
+p7 -> p8;
+
+p8 [label="cifti_meshing:fmriprep_anat"];
+p9 [label="cifti_meshing:mri2mesh"];
+p8 -> p9;
+
+p9 [label="cifti_meshing:mri2mesh"];
+p15 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="spread"];
+p9 -> p15 [label="fs_dirs"];
+
+p9 [label="cifti_meshing:mri2mesh"];
+p11 [shape=point];
+p9 -> p11 [label="mesh_m2m"];
+
+p9 [label="cifti_meshing:mri2mesh"];
+p12 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p9 -> p12;
+
+p9 [label="cifti_meshing:mri2mesh"];
+p10 [shape=point];
+p9 -> p10 [label="t1"];
+
+p12 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p13 [label="cifti_meshing:update_msh"];
+p12 -> p13 [label="update_msh_input"];
+
+p13 [label="cifti_meshing:update_msh"];
+p127 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p13 -> p127 [label="msh"];
+
+p14 [shape=point,label="",fixedsize=true,width=0.1];
+p15 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="spread"];
+p14 -> p15;
+
+p15 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="spread"];
+p17 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="spread"];
+p15 -> p17;
+
+p16 [shape=point,label="",fixedsize=true,width=0.1];
+p17 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="spread"];
+p16 -> p17;
+
+p17 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="spread"];
+p18 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p17 -> p18;
+
+p18 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p19 [label="make_giftis:convert_fs2gifti"];
+p18 -> p19 [label="sub_surfaces"];
+
+p19 [label="make_giftis:convert_fs2gifti"];
+p20 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p19 -> p20;
+
+p20 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p21 [label="make_giftis:assign_structure"];
+p20 -> p21 [label="assign_structure_input"];
+
+p21 [label="make_giftis:assign_structure"];
+p22 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="groupTuple"];
+p21 -> p22;
+
+p22 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="groupTuple"];
+p23 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p22 -> p23;
+
+p23 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p24 [label="make_giftis:compute_midthickness"];
+p23 -> p24 [label="midthickness_input"];
+
+p24 [label="make_giftis:compute_midthickness"];
+p25 [shape=point];
+p24 -> p25 [label="midthick"];
+
+p23 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p26 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p23 -> p26 [label="midthickness_input"];
+
+p26 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p27 [shape=point];
+p26 -> p27 [label="pial"];
+
+p23 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p28 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p23 -> p28 [label="midthickness_input"];
+
+p28 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p29 [shape=point];
+p28 -> p29 [label="white"];
+
+p30 [shape=point,label="",fixedsize=true,width=0.1];
+p31 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="spread"];
+p30 -> p31;
+
+p9 [label="cifti_meshing:mri2mesh"];
+p31 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="spread"];
+p9 -> p31 [label="fs_dirs"];
+
+p31 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="spread"];
+p32 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p31 -> p32;
+
+p32 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p33 [label="registration_wf:convert_sulcal"];
+p32 -> p33 [label="sulcal_input"];
+
+p33 [label="registration_wf:convert_sulcal"];
+p34 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p33 -> p34;
+
+p34 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p35 [label="registration_wf:assign_sulcal"];
+p34 -> p35 [label="assign_input"];
+
+p35 [label="registration_wf:assign_sulcal"];
+p36 [label="registration_wf:invert_sulcal"];
+p35 -> p36;
+
+p36 [label="registration_wf:invert_sulcal"];
+p37 [shape=point];
+p36 -> p37;
+
+p38 [shape=point,label="",fixedsize=true,width=0.1];
+p39 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="spread"];
+p38 -> p39;
+
+p9 [label="cifti_meshing:mri2mesh"];
+p39 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="spread"];
+p9 -> p39 [label="fs_dirs"];
+
+p39 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="spread"];
+p41 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="spread"];
+p39 -> p41;
+
+p40 [shape=point,label="",fixedsize=true,width=0.1];
+p41 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="spread"];
+p40 -> p41;
+
+p41 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="spread"];
+p42 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p41 -> p42;
+
+p42 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p43 [label="registration_wf:convert_sphere"];
+p42 -> p43 [label="registration_spheres"];
+
+p43 [label="registration_wf:convert_sphere"];
+p44 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p43 -> p44;
+
+p44 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p45 [label="registration_wf:assign_sphere"];
+p44 -> p45 [label="assign_sphere_input"];
+
+p45 [label="registration_wf:assign_sphere"];
+p46 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="filter"];
+p45 -> p46;
+
+p46 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="filter"];
+p47 [label="registration_wf:deform_sphere"];
+p46 -> p47 [label="deform_sphere_input"];
+
+p47 [label="registration_wf:deform_sphere"];
+p48 [shape=point];
+p47 -> p48;
+
+p45 [label="registration_wf:assign_sphere"];
+p49 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="filter"];
+p45 -> p49;
+
+p49 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="filter"];
+p50 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p49 -> p50;
+
+p50 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p51 [label="registration_wf:spherical_affine"];
+p50 -> p51 [label="affine_input"];
+
+p51 [label="registration_wf:spherical_affine"];
+p52 [label="registration_wf:normalize_rotation"];
+p51 -> p52;
+
+p52 [label="registration_wf:normalize_rotation"];
+p53 [shape=point];
+p52 -> p53;
+
+p45 [label="registration_wf:assign_sphere"];
+p54 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p45 -> p54;
+
+p54 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p55 [label="registration_wf:apply_affine"];
+p54 -> p55 [label="rotation_input"];
+
+p55 [label="registration_wf:apply_affine"];
+p56 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p55 -> p56;
+
+p56 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p57 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p56 -> p57;
+
+p57 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p58 [label="registration_wf:msm_sulc"];
+p57 -> p58 [label="msm_input"];
+
+p58 [label="registration_wf:msm_sulc"];
+p59 [label="registration_wf:areal_distortion"];
+p58 -> p59;
+
+p59 [label="registration_wf:areal_distortion"];
+p60 [shape=point];
+p59 -> p60;
+
+p58 [label="registration_wf:msm_sulc"];
+p61 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p58 -> p61;
+
+p61 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p62 [shape=point];
+p61 -> p62 [label="msm_sphere"];
+
+p63 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p64 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p63 -> p64 [label="derivatives"];
+
+p64 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p85 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p64 -> p85 [label="cifti"];
+
+p63 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p65 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p63 -> p65 [label="derivatives"];
+
+p65 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p66 [label="weightfunc_wf:calculate_weightfunc_wf:project_mask2surf"];
+p65 -> p66 [label="surfs"];
+
+p66 [label="weightfunc_wf:calculate_weightfunc_wf:project_mask2surf"];
+p67 [shape=point];
+p66 -> p67;
+
+p63 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p68 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p63 -> p68 [label="derivatives"];
+
+p68 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p69 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="transpose"];
+p68 -> p69;
+
+p69 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="transpose"];
+p70 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p69 -> p70;
+
+p70 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p71 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p70 -> p71;
+
+p71 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p72 [label="weightfunc_wf:calculate_weightfunc_wf:clean_img"];
+p71 -> p72 [label="cleaned_input"];
+
+p72 [label="weightfunc_wf:calculate_weightfunc_wf:clean_img"];
+p75 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p72 -> p75;
+
+p63 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p73 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p63 -> p73 [label="derivatives"];
+
+p73 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p74 [shape=point];
+p73 -> p74 [label="cifti_buffer"];
+
+p75 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p76 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p75 -> p76;
+
+p76 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p77 [label="weightfunc_wf:calculate_weightfunc_wf:smooth_img"];
+p76 -> p77 [label="smooth_input"];
+
+p77 [label="weightfunc_wf:calculate_weightfunc_wf:smooth_img"];
+p78 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p77 -> p78;
+
+p78 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p79 [label="weightfunc_wf:calculate_weightfunc_wf:calculate_roi_correlation"];
+p78 -> p79 [label="correlation_input"];
+
+p79 [label="weightfunc_wf:calculate_weightfunc_wf:calculate_roi_correlation"];
+p80 [label="weightfunc_wf:calculate_weightfunc_wf:split_cifti"];
+p79 -> p80;
+
+p80 [label="weightfunc_wf:calculate_weightfunc_wf:split_cifti"];
+p83 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p80 -> p83;
+
+p80 [label="weightfunc_wf:calculate_weightfunc_wf:split_cifti"];
+p81 [label="weightfunc_wf:calculate_weightfunc_wf:mask_cortex"];
+p80 -> p81;
+
+p81 [label="weightfunc_wf:calculate_weightfunc_wf:mask_cortex"];
+p82 [shape=point];
+p81 -> p82;
+
+p83 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p84 [label="weightfunc_wf:calculate_weightfunc_wf:create_dense"];
+p83 -> p84 [label="create_dense_input"];
+
+p84 [label="weightfunc_wf:calculate_weightfunc_wf:create_dense"];
+p92 [label="weightfunc_wf:mask_wf:split_weightfunc"];
+p84 -> p92 [label="dscalar"];
+
+p85 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p86 [label="weightfunc_wf:mask_wf:project_mask2surf"];
+p85 -> p86 [label="project_mask_inputs"];
+
+p86 [label="weightfunc_wf:mask_wf:project_mask2surf"];
+p87 [label="weightfunc_wf:mask_wf:binarize_mask"];
+p86 -> p87;
+
+p87 [label="weightfunc_wf:mask_wf:binarize_mask"];
+p88 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p87 -> p88;
+
+p88 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p89 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p88 -> p89;
+
+p89 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p90 [label="weightfunc_wf:mask_wf:dilate_mask"];
+p89 -> p90 [label="dilate_mask_input"];
+
+p90 [label="weightfunc_wf:mask_wf:dilate_mask"];
+p91 [shape=point];
+p90 -> p91;
+
+p92 [label="weightfunc_wf:mask_wf:split_weightfunc"];
+p94 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p92 -> p94;
+
+p92 [label="weightfunc_wf:mask_wf:split_weightfunc"];
+p93 [shape=point];
+p92 -> p93;
+
+p94 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p95 [label="weightfunc_wf:mask_wf:apply_mask"];
+p94 -> p95 [label="apply_mask_inputs"];
+
+p95 [label="weightfunc_wf:mask_wf:apply_mask"];
+p96 [label="weightfunc_wf:mask_wf:threshold_weightfunc"];
+p95 -> p96;
+
+p96 [label="weightfunc_wf:mask_wf:threshold_weightfunc"];
+p97 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p96 -> p97;
+
+p97 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p98 [label="weightfunc_wf:mask_wf:recombine_weightfunc"];
+p97 -> p98 [label="recombine_inputs"];
+
+p98 [label="weightfunc_wf:mask_wf:recombine_weightfunc"];
+p99 [label="resamplemask_wf:split_dscalar"];
+p98 -> p99 [label="dscalar"];
+
+p99 [label="resamplemask_wf:split_dscalar"];
+p100 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p99 -> p100;
+
+p99 [label="resamplemask_wf:split_dscalar"];
+p102 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p99 -> p102;
+
+p100 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p101 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p100 -> p101;
+
+p101 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p104 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="mix"];
+p101 -> p104 [label="left_resample_input"];
+
+p102 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p103 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p102 -> p103;
+
+p103 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p104 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="mix"];
+p103 -> p104 [label="right_resample_input"];
+
+p104 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="mix"];
+p105 [label="resamplemask_wf:resample_surf"];
+p104 -> p105 [label="resample_input"];
+
+p105 [label="resamplemask_wf:resample_surf"];
+p106 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p105 -> p106;
+
+p106 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p107 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="groupTuple"];
+p106 -> p107;
+
+p107 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="groupTuple"];
+p108 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p107 -> p108;
+
+p108 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p109 [label="resamplemask_wf:recombine"];
+p108 -> p109 [label="recombine_input"];
+
+p109 [label="resamplemask_wf:recombine"];
+p110 [label="centroid_wf:split_dscalar"];
+p109 -> p110 [label="dscalar"];
+
+p110 [label="centroid_wf:split_dscalar"];
+p111 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p110 -> p111;
+
+p110 [label="centroid_wf:split_dscalar"];
+p115 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p110 -> p115;
+
+p111 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p112 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p111 -> p112;
+
+p112 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p113 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p112 -> p113;
+
+p113 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p114 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p113 -> p114;
+
+p114 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p119 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="mix"];
+p114 -> p119 [label="left_project_input"];
+
+p115 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p116 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p115 -> p116;
+
+p116 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p117 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p116 -> p117;
+
+p117 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p118 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p117 -> p118;
+
+p118 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p119 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="mix"];
+p118 -> p119 [label="right_project_input"];
+
+p119 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="mix"];
+p120 [label="centroid_wf:project2vol"];
+p119 -> p120 [label="project_input"];
+
+p120 [label="centroid_wf:project2vol"];
+p121 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="groupTuple"];
+p120 -> p121;
+
+p121 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="groupTuple"];
+p122 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p121 -> p122;
+
+p122 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p123 [label="centroid_wf:add_niftis"];
+p122 -> p123 [label="add_niftis_input"];
+
+p123 [label="centroid_wf:add_niftis"];
+p124 [label="centroid_wf:normalize_vol"];
+p123 -> p124;
+
+p124 [label="centroid_wf:normalize_vol"];
+p125 [label="centroid_wf:compute_weighted_centroid"];
+p124 -> p125;
+
+p125 [label="centroid_wf:compute_weighted_centroid"];
+p126 [shape=point];
+p125 -> p126 [label="centroid"];
+
+p127 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p128 [label="parameterization_wf:extract_surf_patch"];
+p127 -> p128 [label="surf_patch_input"];
+
+p128 [label="parameterization_wf:extract_surf_patch"];
+p129 [label="parameterization_wf:parameterize_surf"];
+p128 -> p129;
+
+p129 [label="parameterization_wf:parameterize_surf"];
+p132 [shape=point];
+p129 -> p132 [label="C"];
+
+p129 [label="parameterization_wf:parameterize_surf"];
+p131 [shape=point];
+p129 -> p131 [label="R"];
+
+p129 [label="parameterization_wf:parameterize_surf"];
+p130 [shape=point];
+p129 -> p130 [label="bounds"];
+
+p84 [label="weightfunc_wf:calculate_weightfunc_wf:create_dense"];
+p133 [label="resampleweightfunc_wf:split_dscalar"];
+p84 -> p133 [label="dscalar"];
+
+p133 [label="resampleweightfunc_wf:split_dscalar"];
+p134 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p133 -> p134;
+
+p133 [label="resampleweightfunc_wf:split_dscalar"];
+p136 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p133 -> p136;
+
+p134 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p135 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p134 -> p135;
+
+p135 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p138 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="mix"];
+p135 -> p138 [label="left_resample_input"];
+
+p136 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="join"];
+p137 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p136 -> p137;
+
+p137 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p138 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="mix"];
+p137 -> p138 [label="right_resample_input"];
+
+p138 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="mix"];
+p139 [label="resampleweightfunc_wf:resample_surf"];
+p138 -> p139 [label="resample_input"];
+
+p139 [label="resampleweightfunc_wf:resample_surf"];
+p140 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p139 -> p140;
+
+p140 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p141 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="groupTuple"];
+p140 -> p141;
+
+p141 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="groupTuple"];
+p142 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p141 -> p142;
+
+p142 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="map"];
+p143 [label="resampleweightfunc_wf:recombine"];
+p142 -> p143 [label="recombine_input"];
+
+p143 [label="resampleweightfunc_wf:recombine"];
+p144 [shape=point];
+p143 -> p144 [label="resampled"];
+
+}

--- a/pipeline/dsl2/boonstim.nf
+++ b/pipeline/dsl2/boonstim.nf
@@ -93,8 +93,7 @@ workflow {
         centroid_wf(resamplemask_wf.out.resampled,make_giftis_result.pial, make_giftis_result.white, make_giftis_result.midthickness, cifti_mesh_result.t1fs_conform)
 
         // Parameterize the surface
-        parameterization_wf(cifti_mesh_result.msh, centroid_wf.out.centroid)
-
+        parameterization_wf(cifti_mesh_result.msh, centroid_wf.out.centroid) 
         // Resample the weightfunc
         resampleweightfunc_wf(weightfunc_wf.out.weightfunc, registration_wf.out.msm_sphere)
         
@@ -118,7 +117,7 @@ workflow {
             cifti_mesh_result.cifti   to: "$params.out", mode: 'copy', pattern: {"./ciftify/*"}
             cifti_mesh_result.fmriprep to: "$params.out", mode: 'copy', pattern: {"./fmriprep/*"}
             cifti_mesh_result.freesurfer to: "$params.out", mode: 'copy', pattern: {"./freesurfer/*"}
-
+            cifti_mesh_result.freesurfer to: "$params.out", mode: 'copy', pattern: {"./freesurfer/${it[0]}"}
             // Meshing outptus
             
 

--- a/pipeline/dsl2/config/debug.nf.config
+++ b/pipeline/dsl2/config/debug.nf.config
@@ -1,0 +1,116 @@
+singularity {
+
+    autoMounts=true
+    enabled=true
+
+}
+
+// BIN DIRECTORY
+params.bin = "/projects/jjeyachandra/BOONStim/pipeline/dsl2/bin"
+
+// COIL TO USE
+params.coil = "/projects/jjeyachandra/simnibs/ccd-files/Magstim_70mm_Fig8.nii.gz"
+
+// CIFTIFY SPEC
+params.simg = "/archive/code/containers/FMRIPREP_CIFTIFY/tigrlab_fmriprep_ciftify_1.3.0.post2-2.3.1-2019-04-04-8ebe3500bebf.img"
+params.ciftify_invocation = "/projects/jjeyachandra/boutiques_jsons/invocations/fmriprep_ciftify-1.3.0.post2-2.3.1_invocation.json"
+params.ciftify_descriptor = "/projects/jjeyachandra/boutiques_jsons/descriptors/fmriprep_ciftify-1.3.0.post2-2.3.1.json"
+
+// FMRIPREP SPEC
+params.anat_invocation = "/projects/jjeyachandra/BOONStim/pipeline/invocations/fmriprep_anat_wf.json"
+params.anat_descriptor = "/projects/jjeyachandra/boutiques_jsons/descriptors/fmriprep-1.3.2.json"
+
+// FREESURFER SPEC
+params.freesurfer = '/projects/jjeyachandra/BOONStim/containers/freesurfer_6.0.1/freesurfer_expert_6.0.1.simg'
+params.license="/opt/quarantine/freesurfer/6.0.0/build/"
+
+// CONNECTOME WORKBENCH SPEC
+params.connectome = '/projects/jjeyachandra/BOONStim/containers/connectome_workbench/connectome_workbench_v1.0-2019-06-05-bbdb3be76afe.simg'
+
+// BIDS-APPS SPEC
+params.work = "/tmp/"
+
+// ATLASES
+params.atlas = "/projects/jjeyachandra/BOONStim/pipeline/templates/"
+
+// MSM
+params.msm = "/projects/jjeyachandra/BOONStim/pipeline/msm_conf/"
+
+// Custom user-defined weight function configuration
+includeConfig "../user/calculate_mentalizing_weightfunc.nf.config"
+params.weightworkflow = "/projects/jjeyachandra/BOONStim/pipeline/dsl2/user/calculate_mentalizing_weightfunc.nf"
+
+// Caching directory
+cacheDir = "/scratch/jjeyachandra/BOONStim/cache"
+
+//Local only for now
+process {
+    withName: fmriprep_anat {
+        
+        storeDir = "$cacheDir/fmriprep_anat"
+        executor = "local"
+        errorStrategy = 'retry'
+        maxRetries = 3
+        queue = "high-moby"
+        clusterOptions = "--time=36:00:00 --mem-per-cpu=2048\
+         --cpus-per-task=4 --job-name boonstim_ciftify\
+         --nodes=1"
+    }
+    
+    withName: ciftify{
+        storeDir = "$cacheDir/ciftify"
+        executor = "local"
+        errorStrategy = 'retry'
+        maxRetries = 3
+        queue = "high-moby"
+        clusterOptions = "--time=36:00:00 --mem-per-cpu=2048\
+         --cpus-per-task=4 --job-name boonstim_ciftify\
+         --nodes=1"
+    }
+
+    withName: mri2mesh{
+        storeDir = "$cacheDir/mri2mesh"
+        container = "/projects/jjeyachandra/BOONStim/containers/simnibs_3.0/mri2mesh_v3.0_v0.2-2019-06-24-1dfbbefb361d.simg"
+        executor = "local"
+        errorStrategy = 'retry'
+        maxRetries = 3
+        queue = 'high-moby'
+        clusterOptions = "--time=36:00:00 --mem-per-cpu=2048\
+         --cpus-per-task=4 --job-name boonstim_ciftify\
+         --nodes=1"
+    }
+
+    withName: msm_sulc{
+        storeDir = "$cacheDir/msm"
+    }
+    
+    withName: update_msh{ storeDir = "$cacheDir/update_msh" }
+    withName: smooth_img{ storeDir = "$cacheDir/smooth_img" }
+    withName: tetrahedral_projection{ storeDir = "$cacheDir/tetrahedral_projection" }
+    withName: optimize_coil { storeDir = "$cacheDir/optimize_coil" }
+
+    withLabel: ciftify{
+        container = "/archive/code/containers/FMRIPREP_CIFTIFY/tigrlab_fmriprep_ciftify_1.3.2-2.3.2-2019-06-07-ba20178606c2.simg"
+        executor = 'local'
+    }
+
+    withLabel: freesurfer{
+        container = '/projects/jjeyachandra/BOONStim/containers/freesurfer_6.0.1/freesurfer_expert_6.0.1.simg'
+        executor = 'local'
+    }
+
+    withLabel: connectome{
+        container = '/projects/jjeyachandra/BOONStim/containers/connectome_workbench/connectome_workbench_v1.0-2019-06-05-bbdb3be76afe.simg'
+        executor = 'local'
+    }
+
+    withLabel: numpy{
+        container ="/projects/jjeyachandra/BOONStim/containers/rtms_bayesian/rtms_bayesian_v0.4-2019-09-09-e99bae9f511b.simg"
+        executor = "local"
+
+    }
+
+
+
+}
+

--- a/pipeline/dsl2/modules/boonstim_out_wf.nf
+++ b/pipeline/dsl2/modules/boonstim_out_wf.nf
@@ -1,0 +1,12 @@
+nextflow.preview.dsl=2
+
+workflow output_wf{
+
+    get:
+        pial
+        white
+        midthick
+        msm
+        
+
+}

--- a/pipeline/dsl2/modules/cifti_mesh_wf.nf
+++ b/pipeline/dsl2/modules/cifti_mesh_wf.nf
@@ -37,9 +37,9 @@ process ciftify{
     tuple val(sub), path(json)
 
     output:
-    tuple val(sub), path('fmriprep'), emit: fmriprep
-    tuple val(sub), path('ciftify'), emit: ciftify
-    tuple val(sub), path('freesurfer'), emit: freesurfer
+    tuple val(sub), path("fmriprep/${sub}"), emit: fmriprep
+    tuple val(sub), path("ciftify/${sub}"), emit: ciftify
+    tuple val(sub), path("freesurfer/${sub}"), emit: freesurfer
 
     shell:
     '''

--- a/pipeline/dsl2/modules/cifti_mesh_wf.nf
+++ b/pipeline/dsl2/modules/cifti_mesh_wf.nf
@@ -145,7 +145,7 @@ process mri2mesh {
 process update_msh{
 
     beforeScript 'source /etc/profile'
-    container "/projects/jjeyachandra/BOONStim/containers/rtms_bayesian/rtms_bayesian_v0.4-2019-09-09-e99bae9f511b.simg"
+    label 'numpy'
     
     input:
     tuple val(sub), path('sub.geo'), path(m2m)

--- a/pipeline/dsl2/modules/fs2gifti.nf
+++ b/pipeline/dsl2/modules/fs2gifti.nf
@@ -12,17 +12,17 @@ process convert_fs2gifti{
     tuple val(sub), val(hemi), val(surf), path(fs_surf)
 
     output:
-    tuple val(sub), val(hemi), path("${hemi}.${surf}.surf.gii"), emit: hemi_surf
+    tuple val(sub), val(hemi), path("${surf}.surf.gii"), emit: hemi_surf
 
     shell:
     '''
     export FS_LICENSE=/license/license.txt
 
-    mris_convert !{fs_surf} !{hemi}.!{surf}.surf.gii
+    mris_convert !{fs_surf} !{surf}.surf.gii
     
     hemi="!{hemi}"
-    mv ${hemi,,}h.!{hemi}.!{surf}.surf.gii \
-        !{hemi}.!{surf}.surf.gii
+    mv ${hemi,,}h.!{surf}.surf.gii \
+        !{surf}.surf.gii
     '''
 
 }
@@ -36,12 +36,12 @@ process assign_structure {
     tuple val(sub), val(hemi), val(structure), path(gifti)
 
     output:
-    tuple val(sub), val(hemi), path("assigned_$gifti"), emit: gifti
+    tuple val(sub), val(hemi), path("${sub}.${hemi}.${gifti}"), emit: gifti
 
     shell:
     '''
-    cp -L !{gifti} assigned_!{gifti}
-    wb_command -set-structure assigned_!{gifti} !{structure}
+    cp -L !{gifti} !{sub}.!{hemi}.!{gifti}
+    wb_command -set-structure !{sub}.!{hemi}.!{gifti} !{structure}
     '''
 
 }
@@ -54,12 +54,12 @@ process compute_midthickness {
     tuple val(sub), val(hemi), path(pial), path(white)
 
     output:
-    tuple val(sub), val(hemi), path("${hemi}.midthickness.surf.gii"), emit: midthickness
+    tuple val(sub), val(hemi), path("${sub}.${hemi}.midthickness.surf.gii"), emit: midthickness
 
     """
     wb_command -surface-average -surf ${pial} \
                                 -surf ${white} \
-                                ${hemi}.midthickness.surf.gii
+                                ${sub}.${hemi}.midthickness.surf.gii
     """
 
 }

--- a/pipeline/dsl2/modules/register_fs2cifti_wf.nf
+++ b/pipeline/dsl2/modules/register_fs2cifti_wf.nf
@@ -189,7 +189,7 @@ process msm_sulc {
     tuple val(sub), val(hemi), path(sphere), path(sulc), val(structure)
 
     output:
-    tuple val(sub), val(hemi), path(sphere), path("${hemi}.sphere.reg_msm.surf.gii")
+    tuple val(sub), val(hemi), path(sphere), path("${sub}.${hemi}.sphere.reg_msm.surf.gii")
 
     shell:
     '''
@@ -202,9 +202,9 @@ process msm_sulc {
              --verbose
 
     mv "!{hemi}.sphere.reg.surf.gii" \
-       "!{hemi}.sphere.reg_msm.surf.gii"
+       "!{sub}.!{hemi}.sphere.reg_msm.surf.gii"
 
-    wb_command -set-structure !{hemi}.sphere.reg_msm.surf.gii \
+    wb_command -set-structure !{sub}.!{hemi}.sphere.reg_msm.surf.gii \
                                 !{structure}
     '''
 
@@ -218,13 +218,13 @@ process areal_distortion{
     tuple val(sub), val(hemi), path(sphere), path(msm_sphere)
 
     output:
-    tuple val(sub), val(hemi), path("${hemi}.areal_distortion.shape.gii"), emit: areal
+    tuple val(sub), val(hemi), path("${sub}.${hemi}.areal_distortion.shape.gii"), emit: areal
 
     """
     wb_command -surface-distortion \
                 ${sphere} \
                 ${msm_sphere} \
-                ${hemi}.areal_distortion.shape.gii
+                ${sub}.${hemi}.areal_distortion.shape.gii
     """
 
     
@@ -325,6 +325,4 @@ workflow registration_wf {
         emit:
             msm_sphere = msm_sphere_out
             
-                                                    
-                            
 }

--- a/pipeline/dsl2/user/compute_dmpfc_connectivity.nf
+++ b/pipeline/dsl2/user/compute_dmpfc_connectivity.nf
@@ -165,9 +165,9 @@ workflow calculate_weightfunc_wf {
         surfs = derivatives
                         .map{s,f,c ->   [
                                             s,
-                                            "${c}/${s}/MNINonLinear/fsaverage_LR32k/${s}.L.midthickness.32k_fs_LR.surf.gii",
-                                            "${c}/${s}/MNINonLinear/fsaverage_LR32k/${s}.L.white.32k_fs_LR.surf.gii",
-                                            "${c}/${s}/MNINonLinear/fsaverage_LR32k/${s}.L.pial.32k_fs_LR.surf.gii",
+                                            "${s}/MNINonLinear/fsaverage_LR32k/${s}.L.midthickness.32k_fs_LR.surf.gii",
+                                            "${s}/MNINonLinear/fsaverage_LR32k/${s}.L.white.32k_fs_LR.surf.gii",
+                                            "${s}/MNINonLinear/fsaverage_LR32k/${s}.L.pial.32k_fs_LR.surf.gii",
                                             "${params.inverse_mask}"
                                         ]
                             }
@@ -178,7 +178,7 @@ workflow calculate_weightfunc_wf {
                             .map{s,f,c ->   [
                                                 s,
                                                 f,
-                                                new FileNameByRegexFinder().getFileNames("${c}/${s}",".*MNINonLinear/Results/.*(REST|rest).*/.*dtseries.nii")
+                                                new FileNameByRegexFinder().getFileNames("${s}",".*MNINonLinear/Results/.*(REST|rest).*/.*dtseries.nii")
                                                 
                                             ]
                                 }
@@ -191,7 +191,7 @@ workflow calculate_weightfunc_wf {
                                 }
                             .map{ s,f,d,ses,ident ->    [
                                                             s,d,
-                                                            new FileNameByRegexFinder().getFileNames("$f/$s/$ses/func", ".*${ident}.*confound.*tsv")[0],
+                                                            new FileNameByRegexFinder().getFileNames("$s/$ses/func", ".*${ident}.*confound.*tsv")[0],
                                                             "${params.clean_config}"
                                                         ]
                                 }
@@ -204,8 +204,8 @@ workflow calculate_weightfunc_wf {
         smooth_input = clean_img.out.clean_dtseries.join(cifti_buffer, by:0)
                                 .map{ s,i,c ->  [
                                                     s,i,
-                                                    "${c}/${s}/MNINonLinear/fsaverage_LR32k/${s}.L.midthickness.32k_fs_LR.surf.gii",
-                                                    "${c}/${s}/MNINonLinear/fsaverage_LR32k/${s}.R.midthickness.32k_fs_LR.surf.gii"
+                                                    "${s}/MNINonLinear/fsaverage_LR32k/${s}.L.midthickness.32k_fs_LR.surf.gii",
+                                                    "${s}/MNINonLinear/fsaverage_LR32k/${s}.R.midthickness.32k_fs_LR.surf.gii"
                                                 ]
                                     }
         smooth_img(smooth_input)

--- a/pipeline/dsl2/user/make_dmpfc_mask.nf
+++ b/pipeline/dsl2/user/make_dmpfc_mask.nf
@@ -125,12 +125,12 @@ process recombine_weightfunc{
     tuple val(sub), path(left_shape), path(right_shape)
 
     output:
-    tuple val(sub), path('masked_weightfunc.dscalar.nii'), emit: weighted_mask
+    tuple val(sub), path("${sub}.weightfuncmask.dscalar.nii"), emit: weighted_mask
     
     shell:
     '''
     wb_command -cifti-create-dense-scalar \
-                masked_weightfunc.dscalar.nii \
+                !{sub}.weightfuncmask.dscalar.nii \
                 -left-metric !{left_shape} \
                 -right-metric !{right_shape}
     '''
@@ -149,9 +149,9 @@ workflow mask_wf {
         project_mask_inputs = cifti
                                 .map{ s,c ->    [
                                                     s,
-                                                    "${c}/${s}/MNINonLinear/fsaverage_LR32k/${s}.L.white.32k_fs_LR.surf.gii",
-                                                    "${c}/${s}/MNINonLinear/fsaverage_LR32k/${s}.L.pial.32k_fs_LR.surf.gii",
-                                                            "${c}/${s}/MNINonLinear/fsaverage_LR32k/${s}.L.midthickness.32k_fs_LR.surf.gii",
+                                                    "${c}/MNINonLinear/fsaverage_LR32k/${s}.L.white.32k_fs_LR.surf.gii",
+                                                    "${c}/MNINonLinear/fsaverage_LR32k/${s}.L.pial.32k_fs_LR.surf.gii",
+                                                            "${c}/MNINonLinear/fsaverage_LR32k/${s}.L.midthickness.32k_fs_LR.surf.gii",
                                                     "${params.mask}"
                                                 ]
                                     }
@@ -165,7 +165,7 @@ workflow mask_wf {
                                         .join(cifti, by: 0)
                                         .map{ s,b,c ->  [   
                                                             s,b,
-                                                            "${c}/${s}/MNINonLinear/fsaverage_LR32k/${s}.L.midthickness.32k_fs_LR.surf.gii"
+                                                            "${c}/MNINonLinear/fsaverage_LR32k/${s}.L.midthickness.32k_fs_LR.surf.gii"
                                                         ]
                                             }
         dilate_mask(dilate_mask_input)


### PR DESCRIPTION
# Major Changes

- Publishing for DSL2 added
- Modified ciftify/fmriprep outputs so subject subdirectory is passed around directly instead of the ciftify
- Modified outputs of some processes to have better control over publishing
- append subject ID to all processes which generate workflow outputs
-  mri2mesh and update_msh now use the rTMS bayesian container through a label rather than direct reference in the process