### PR TITLE
[ENH]: Optional T2 inclusion

### DIFF
--- a/boonstim.nf
+++ b/boonstim.nf
@@ -113,6 +113,8 @@ parser.addOptional("--use-scratch",
     "Use a scratch directory, can provide a path, an empty string ('') to disable"
     + ", note that by default it will use the system default temporary directory",
     "SCRATCH")
+parser.addOptional("--include_t2",
+    "Attempt to pull a T2w image from BIDS directory when reconstructing the head model")
 
 missingArgs = parser.isMissingRequired()
 missingConfig = parser.isMissingConfig()

--- a/modules/cifti_mesh_wf.nf
+++ b/modules/cifti_mesh_wf.nf
@@ -468,11 +468,10 @@ workflow cifti_meshing_wf {
         // Set up fMRIPrep anatomical pre-processing
         fmriprep_anat_wf(subs)
 
-        mri2mesh_input = fmriprep_anat_wf.out.preproc_t1.map { s, t1 ->
+        mri2mesh(
+        fmriprep_anat_wf.out.preproc_t1.map { s, t1 ->
             [ s, t1, try_fetch_t2("${params.bids}/${s}/**/*T2w.nii.gz") ]
-        } | view
-
-        mri2mesh(mri2mesh_input)
+        })
 
         // Full fmriprep/ciftify pipeline
         fmriprep_wf(subs)

--- a/modules/cifti_mesh_wf.nf
+++ b/modules/cifti_mesh_wf.nf
@@ -12,8 +12,8 @@ def try_fetch_t2 (path) {
 
     def t2s = file(path)
 
-    if (!params.include_t2w.toBoolean()) {
-        log.info("params.include_t2w set to not true, skipping T2 inclusion")
+    if (!params.include_t2.toBoolean()) {
+        log.info("params.include_t2 set to not true, skipping T2 inclusion")
         file(params.null_file)
     }
     else if (t2s.size()) > 1 {
@@ -444,7 +444,7 @@ workflow cifti_meshing_wf {
         ciftify_invocation: Path to Ciftify invocation file
         license: Path to Freesurfer license file
         resources: Path to additional resources folder
-        include_t2w (bool): Include T2w image from BIDS directory in mri2mesh reconstruction
+        include_t2 (bool): Include T2w image from BIDS directory in mri2mesh reconstruction
 
     Outputs:
         cifti (channel): (subject, cifti: Path) Ciftify subject output path


### PR DESCRIPTION
T2 files from the raw BIDS folder can be included in the mri2mesh step using `--include_t2` command-line argument.

