### PR TITLE
ENH: Make coil flip optional

### DIFF
--- a/boonstim.nf
+++ b/boonstim.nf
@@ -109,10 +109,14 @@ parser.addOptional("--cache_dir",
     "Create a cache directory to store intermediate results to speed up reruns",
     "CACHE_DIR")
 
-parser.addOptional("--use-scratch",
+parser.addOptional("--use_scratch",
     "Use a scratch directory, can provide a path, an empty string ('') to disable"
     + ", note that by default it will use the system default temporary directory",
     "SCRATCH")
+
+parser.addOptional("--coil_handle_can_point_anterior",
+    "Allow the final coil handle orientation to be able to point anteriorly. Otherwise"
+    + " will be flipped to ensure it is always pointing posterior")
 
 missingArgs = parser.isMissingRequired()
 missingConfig = parser.isMissingConfig()

--- a/containers/fieldopt/Dockerfile
+++ b/containers/fieldopt/Dockerfile
@@ -2,6 +2,6 @@ FROM fieldopt:dev
 
 RUN	apt-get update \
 	&& apt-get install -y --no-install-recommends xvfb
-RUN	pip install pyvista
+RUN	pip install pyvista pythreejs
 
 ENTRYPOINT ["/bin/bash", "-c"]

--- a/modules/neuronav.nf
+++ b/modules/neuronav.nf
@@ -1,5 +1,8 @@
 nextflow.preview.dsl=2
 
+// Parameter that will allow the coil angle to point posteriorly
+params.coil_handle_can_point_anterior = false
+
 process reorient_coil{
 
 
@@ -189,6 +192,10 @@ workflow neuronav_wf {
 
     Arguments:
         msn (channel): (subject, msn: Path) Optimal matsimnibs matrix
+    
+    Params:
+        coil_handle_can_point_anterior (bool): Allow coil angle to point anteriorly
+            Default is to constrain it to point posteriorly
 
     Outputs:
         brainsight (channel): (subject, brainsight: Path) Brainsight coordinates
@@ -204,8 +211,15 @@ workflow neuronav_wf {
         msn
 
     main:
-        reorient_coil(msn)
-        brainsight_transform(reorient_coil.out.reoriented)
+        
+        if ( params.coil_handle_can_point_anterior.toBoolean() ) {
+            final_orientation = msn
+        } else {
+            reorient_coil(msn)
+            final_orientation =reorient_coil.out.reoriented
+        }
+
+        brainsight_transform(final_orientation)
         localite_transform(reorient_coil.out.reoriented)
 
         publish_neuronav(


### PR DESCRIPTION
Add command-line argument to disable the coil flip step which avoid anteriorly pointing coil handles via `--coil_handle_can_point_anterior`